### PR TITLE
Set window.location to notification url-path on notification tap

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,7 +11,7 @@ const Colors = {
 };
 
 export default function App() {
-  usePushNotificationHandler(this);
+  usePushNotificationHandler(this, webViewUrl);
   useDeepLinkHandler(this, webViewUrl);
 
   return (

--- a/src/nativeWebBridge.js
+++ b/src/nativeWebBridge.js
@@ -70,7 +70,7 @@ export function usePushNotificationHandler(component, webViewUrl) {
                 console.log("Notification tapped!", notification.data);
                 const notificationPath = notification.data['url-path'];
                 if (notificationPath) {
-                    const resolved = url.resolve(webViewUrl, notification.data['url-path']);
+                    const resolved = url.resolve(webViewUrl, notificationPath);
                     const cmd = `window.location = '${resolved}'; true;`;
                     console.log(cmd);
                     this.webref.injectJavaScript(cmd);

--- a/src/nativeWebBridge.js
+++ b/src/nativeWebBridge.js
@@ -57,10 +57,13 @@ export function usePushNotificationHandler(component, webViewUrl) {
             // display an in-app notification, and so there's nothing to be done on this side of the bridge.
             if (notification.origin !== 'received') {
                 console.log("Notification tapped!", notification.data);
-                const resolved = url.resolve(webViewUrl, notification.data['url-path']);
-                const cmd = `window.location = '${resolved}'; true;`;
-                console.log(cmd);
-                this.webref.injectJavaScript(cmd);
+                const notificationPath = notification.data['url-path'];
+                if (notificationPath) {
+                    const resolved = url.resolve(webViewUrl, notification.data['url-path']);
+                    const cmd = `window.location = '${resolved}'; true;`;
+                    console.log(cmd);
+                    this.webref.injectJavaScript(cmd);
+                }
             }
         }
         Notifications.addListener(handleNotification.bind(component));

--- a/src/nativeWebBridge.js
+++ b/src/nativeWebBridge.js
@@ -49,7 +49,7 @@ const bridgeGetDeepLinkOrigin = async (webref) => {
 }
 
 
-export function usePushNotificationHandler(component) {
+export function usePushNotificationHandler(component, webViewUrl) {
     useEffect(() => {
         function handleNotification(notification) {
             // Expo sets origin='received' when a push notification is received while app is foregrounded,
@@ -57,7 +57,8 @@ export function usePushNotificationHandler(component) {
             // display an in-app notification, and so there's nothing to be done on this side of the bridge.
             if (notification.origin !== 'received') {
                 console.log("Notification tapped!", notification.data);
-                const cmd = `oc.web.expo.on_push_notification_tapped('${stringifyBridgeData(notification.data)}'); true;`;
+                const resolved = url.resolve(webViewUrl, notification.data['url-path']);
+                const cmd = `window.location = '${resolved}'; true;`;
                 console.log(cmd);
                 this.webref.injectJavaScript(cmd);
             }


### PR DESCRIPTION
Trello: https://trello.com/c/2IcGaZ9f/2194-modify-notification-payloads-to-contain-url-to-simplify-mobile-push-notification-tap-handling

Linked PRs:
- Web: https://github.com/open-company/open-company-web/pull/1026
- Storage: https://github.com/open-company/open-company-storage/pull/221
- Notify: https://github.com/open-company/open-company-notify/pull/17

Use the latest staging build of mobile for iOS/Android (see #devops channel in Slack)

To test:
- Open the mobile app
- Log in with user A
- Make sure user A has enabled push notifications. To trigger the push notification dialog again, re-install the mobile app.
- Put the mobile app in the background (e.g. go back to home screen)
- With user B on web, mention user A in a comment
- [ ] User A should receive a push notification on mobile
- Tap the push notification
- [ ] Are you taken to the proper post/comment?
- Completely quit the mobile application
- With user B, mention user A again in a comment
- Tap the push notification
- [x] Once the app is booted, are you again taken to the proper post/comment?
- Repeat these tests for the other notification types (i.e. follow-ups, mention user A in post body, reminder creation, etc)
- [ ] Do the above tests work for both backgrounded and cold-started applications? 

Regression test:
- Keep the app foregrounded
- Trigger a notification for user A on mobile
- [x] Do you see an in-app notification?
- [x] Did you **not** receive a push notification?
- [x] Does tapping the in-app notification bring you to the proper place? 